### PR TITLE
Test python interface for OSX

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,13 +7,7 @@ echo "build.sh updated CXXFLAGS=${CXXFLAGS}"
 # Build for these backend data formats
 echo "asp fits guppi lwa sigproc vdif" > backends.list
 
-# Extra platform-specific configure options
-CONFIG_OPTS=""
-if [[ "${target_platform}" == osx-* ]]; then
-	CONFIG_OPTS="--disable-python"
-fi
-
-./configure --prefix=${PREFIX} --disable-local --enable-shared ${CONFIG_OPTS} \
+./configure --prefix=${PREFIX} --disable-local --enable-shared \
 	  --includedir=${PREFIX}/include/dspsr \
 	    PGPLOT_DIR=${PREFIX}/include/pgplot
 make -j${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
         - shell_for_flags.patch
         
 build:
-    number: 2
+    number: 3
     skip: true  # [win or (python_impl == 'pypy')]
     run_exports:
       - {{ pin_subpackage('dspsr', exact=True) }}
@@ -30,19 +30,19 @@ requirements:
         - automake
         - libtool
         - pkg-config
-        - swig  # [linux]
+        - swig
     host:
         - psrchive
         - cfitsio
         - pgplot
-        - python {{ python }}  # [linux]
-        - numpy  # [linux]
+        - python {{ python }}
+        - numpy
     run:
         - {{ pin_compatible('psrchive', exact=True) }}
         - cfitsio
         - {{ pin_compatible('pgplot') }}
-        - python  # [linux]
-        - {{ pin_compatible('numpy') }}  # [linux]
+        - python
+        - {{ pin_compatible('numpy') }}
 
 test:
     commands:
@@ -72,7 +72,7 @@ test:
         - test -f $PREFIX/lib/libdspstats$SHLIB_EXT
         - test -f $PREFIX/include/dspsr/dsp/dsp.h
     imports:
-        - dspsr  # [linux]
+        - dspsr
 
 about:
     home: http://dspsr.sourceforge.net/


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please add any other relevant info below:
-->
This is a test to see if the dspsr python interface can be built currently for OSX.  It builds successfully on my local Mac dev system, and I don't remember at this point why we had to disable it for conda-forge.  Re-enabling it here as a test to see what happens.
